### PR TITLE
allow to define service name

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -24,6 +24,8 @@ alertmanager_bot_consul_url: "http://127.0.0.1:8500"
 alertmanager_bot_telegram_admins: []
 alertmanager_bot_telegram_token: "example"
 
+alertmanager_bot_service_name: "alertmanager_bot"
+
 alertmanager_bot_default_template_file: default.tmpl
 
 alertmanager_bot_env_vars: []

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -3,5 +3,5 @@
 - name: restart alertmanager bot
   systemd:
     daemon_reload: true
-    name: alertmanager_bot
+    name: "{{ alertmanager_bot_service_name }}"
     state: restarted

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -83,7 +83,7 @@
 - name: create systemd service unit
   template:
     src: alertmanager_bot.service.j2
-    dest: /etc/systemd/system/alertmanager_bot.service
+    dest: "/etc/systemd/system/{{ alertmanager_bot_service_name }}.service"
     owner: root
     group: root
     mode: 0644

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -6,6 +6,6 @@
 
 - name: ensure alertmanager_bot service is started and enabled
   systemd:
-    name: alertmanager_bot
+    name: "{{ alertmanager_bot_service_name }}"
     state: started
     enabled: true

--- a/templates/alertmanager_bot.service.j2
+++ b/templates/alertmanager_bot.service.j2
@@ -36,7 +36,7 @@ ExecStart={{ alertmanager_bot_release_dir }}/alertmanager_bot \
 
 KillMode=process
 
-SyslogIdentifier=alertmanager_bot
+SyslogIdentifier={{ alertmanager_bot_service_name }}
 Restart=always
 RestartSec=30
 


### PR DESCRIPTION
This is useful when you're using different bots (tokens) on same system