### PR TITLE
Remove unsupported option in get_url module

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ Ansible role for [Alertmanager Bot](https://github.com/metalmatze/alertmanager-b
 * Ubuntu 16.04
 * CentOS 7
 * Debian 9
+* Debian 10
 
 Requirements
 ------------

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -47,7 +47,6 @@
   get_url:
     url: "{{ alertmanager_bot_download_url }}"
     dest: "{{ deploy_helper.new_release_path }}/alertmanager_bot"
-    remote_src: true
   register: _download_archive
   until: _download_archive is succeeded
   retries: 5


### PR DESCRIPTION
Have used the role under Debian 10.7 with Ansible 2.10.4 and encountered this error. Please also upload to ansible galaxy.